### PR TITLE
Skip `undefined` function callbacks and properties

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -86,4 +86,24 @@ describe('mergeProps', () => {
       { unknown })
     ).toThrow(/unknown/);
   })
+
+  test("undefined functions are skipped", () => {
+    let tape = "";
+    const one = () => tape += "only one";
+
+    mergeProps(
+      { onClick: one },
+      { onClick: undefined }
+    ).onClick();
+
+    expect(tape).toBe("only one");
+  });
+
+  test("undefined values are skipped", () => {
+    expect(mergeProps(
+      { isDisabled: undefined }, 
+      { isDisabled: true },
+      { isDisabled: undefined }
+    ).isDisabled).toBe(true)
+  })
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ function pushProp(
       oldFn(...args);
       (value as Function)(...args);
     } : value;
+  } else if (value === undefined) {
+    return
   } else if (!(key in target)) {
     target[key] = value;
   } else {
@@ -36,7 +38,10 @@ export default function mergeProps<T extends {}[]>(...props: T): {
   [K in keyof UnionToIntersection<T[number]>]:
       K extends 'className' ? string :
       K extends 'style' ? UnionToIntersection<T[number]>[K] :
-      Extract<T[number], { [Q in K]: unknown }>[K];
+      Exclude<
+        Extract<T[number], { [Q in K]: unknown }>[K],
+        undefined
+      >;
 } {
   if (props.length === 1) {
     return props[0] as any;


### PR DESCRIPTION
Hi and thank you for this little helper!

In my usage, I have some hooks generating properties and they can be something like `{ onClick: undefined }` if they are empty. Currently, the functions throws in this case, which was unexpected for me since not defined properties are handled well.

Instead, undefined values will be skipped, which also helps for single properties.