### PR TITLE
pass through equal primitive values

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -106,4 +106,17 @@ describe('mergeProps', () => {
       { isDisabled: undefined }
     ).isDisabled).toBe(true)
   })
+
+  test('same string properties are passed through', () => {
+    expect(mergeProps(
+      { label: "Don't panic" }, 
+      { label: "Don't panic" }
+    ).label).toBe("Don't panic")
+  })
+  test('same number properties are passed through', () => {
+    expect(mergeProps(
+      { value: 42 }, 
+      { value: 42 }
+    ).value).toBe(42)
+  })
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,12 @@ function pushProp(
       oldFn(...args);
       (value as Function)(...args);
     } : value;
-  } else if (value === undefined) {
+  } else if (
+      // skip merging undefined values
+      value === undefined ||
+      // skip if both value are the same primitive value
+      (typeof value !== 'object' && value === target[key])
+    ) {
     return
   } else if (!(key in target)) {
     target[key] = value;


### PR DESCRIPTION
Hi,
this PR fixes the issue if you try to merge props with the same primitive value. You already added a test to prevent this behaviour for object types but I'm unsure why. 

Im my use case I have something like this and the change makes it possible to use `mergeProps` for it

```js
// props may get `aria-label`
function Input(props) {
  // labelProps create or pass through all label related props (like IDs, htmlFor etc.)
  const { labelProps, inputProps } = useLabel(props)

  return <>
    {/* ... */}
    <label {mergeProps(labelProps, props)
    {/* ... */}
  </>;
}
```

Until now it fails since `aria-label` is in both object, even so it's the same value