### PR TITLE
Correctly generate CJS module type definitions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function pushProp(
  *  - duplicate functions (to be used for event handlers) get called in order from left to right
  * @param props Sets of props to merge together. Later props have precedence.
  */
-export default function mergeProps<T extends {}[]>(...props: T): {
+export = function mergeProps<T extends {}[]>(...props: T): {
   [K in keyof UnionToIntersection<T[number]>]:
       K extends 'className' ? string :
       K extends 'style' ? UnionToIntersection<T[number]>[K] :


### PR DESCRIPTION
The current `tsconfig.json` settings in combination with the way `mergeProps` is exported will result in incorrect type declarations. For some reason only becomes apparent (as TS throws an error) when trying to import this from a project that uses `module: 'node16'` in their own type definitions. This way of exporting `mergeProps` will generate correct type declarations.